### PR TITLE
AR ios - Reality Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This plugin is still a work in progress. Keep posted for updates or contribute b
 If you still want to use the plugin before it's officially released, add the following to your `pubspec.yaml` file:
 ```yaml
 dependencies:
-  arkit_plugin:
+  ar_flutter_plugin:
     git: git://github.com/CariusLars/ar_flutter_plugin.git
 ```
 
@@ -22,7 +22,8 @@ To try out the plugin, it is best to have a look at one of the following example
 | --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | Debug Options         | Simple AR scene with toggles to visualize the world origin, feature points and tracked planes                                                                                                                                                                                          | [Debug Options Code](https://github.com/CariusLars/ar_flutter_plugin/blob/main/example/lib/examples/debugoptionsexample.dart)                |
 | Local & Online Objets | AR scene with buttons to place GLTF objects from the flutter asset folders or GLB objects from the internet at a given position, rotation and scale. Additional buttons allow to modify scale, position and orientation with regard to the world origin after objects have been placed | [Local & Online Objects Code](https://github.com/CariusLars/ar_flutter_plugin/blob/main/example/lib/examples/localandwebobjectsexample.dart) |
-| Cloud Anchors Example | NOT IMPLEMENTED YET. Will allow to place, upload and download objects.                                                                                                                                                                                                                 | [Cloud Anchors Code](https://github.com/CariusLars/ar_flutter_plugin/blob/main/example/lib/examples/cloudanchorexample.dart)                 |
+| Objects on Planes     | AR Scene in which tapping on a plane creates an anchor with a 3D model attached to it                                                                                                                                                                                                  | [Objects on Planes Code](https://github.com/CariusLars/ar_flutter_plugin/blob/main/example/lib/examples/objectsonplanesexample.dart)         |
+| Cloud Anchors         | NOT IMPLEMENTED YET. Will allow to place, upload and download objects.                                                                                                                                                                                                                 | [Cloud Anchors Code](https://github.com/CariusLars/ar_flutter_plugin/blob/main/example/lib/examples/cloudanchorexample.dart)                 |
 
 
 ## Roadmap

--- a/android/src/main/kotlin/io/carius/lars/ar_flutter_plugin/Serialization/Serializers.kt
+++ b/android/src/main/kotlin/io/carius/lars/ar_flutter_plugin/Serialization/Serializers.kt
@@ -1,0 +1,35 @@
+package io.carius.lars.ar_flutter_plugin.Serialization
+
+import com.google.ar.core.HitResult
+import com.google.ar.core.Plane
+import com.google.ar.core.Point
+import com.google.ar.core.Pose
+
+fun serializeHitResult(hitResult: HitResult): HashMap<String, Any> {
+    val serializedHitResult = HashMap<String,Any>()
+
+    if (hitResult.trackable is Plane && (hitResult.trackable as Plane).isPoseInPolygon(hitResult.hitPose)) {
+        serializedHitResult["type"] = 1 // Type plane
+    }
+    else if (hitResult.trackable is Point){
+        serializedHitResult["type"] = 2 // Type point
+    } else {
+        serializedHitResult["type"] = 0 // Type undefined
+    }
+
+    serializedHitResult["distance"] = hitResult.distance.toDouble()
+    serializedHitResult["worldTransform"] = serializePose(hitResult.hitPose)
+
+    return serializedHitResult
+}
+
+fun serializePose(pose: Pose): DoubleArray {
+    val serializedPose = FloatArray(16)
+    pose.toMatrix(serializedPose, 0)
+    // copy into double Array
+    val serializedPoseDouble = DoubleArray(serializedPose.size)
+    for (i in serializedPose.indices) {
+        serializedPoseDouble[i] = serializedPose[i].toDouble()
+    }
+    return serializedPoseDouble
+}

--- a/example/lib/examples/debugoptionsexample.dart
+++ b/example/lib/examples/debugoptionsexample.dart
@@ -17,6 +17,7 @@ class _DebugOptionsWidgetState extends State<DebugOptionsWidget> {
   bool _showPlanes = false;
   bool _showWorldOrigin = false;
   String _planeTexturePath = "Images/triangle.png";
+  bool _handleTaps = false;
 
   @override
   Widget build(BuildContext context) {
@@ -87,6 +88,7 @@ class _DebugOptionsWidgetState extends State<DebugOptionsWidget> {
           showPlanes: _showPlanes,
           customPlaneTexturePath: _planeTexturePath,
           showWorldOrigin: _showWorldOrigin,
+          handleTaps: _handleTaps,
         );
     this.arObjectManager.onInitialize();
   }

--- a/example/lib/examples/localandwebobjectsexample.dart
+++ b/example/lib/examples/localandwebobjectsexample.dart
@@ -76,6 +76,7 @@ class _LocalAndWebObjectsWidgetState extends State<LocalAndWebObjectsWidget> {
           showPlanes: true,
           customPlaneTexturePath: "Images/triangle.png",
           showWorldOrigin: true,
+          handleTaps: false,
         );
     this.arObjectManager.onInitialize();
   }

--- a/example/lib/examples/objectsonplanesexample.dart
+++ b/example/lib/examples/objectsonplanesexample.dart
@@ -1,0 +1,97 @@
+import 'package:ar_flutter_plugin/managers/ar_session_manager.dart';
+import 'package:ar_flutter_plugin/managers/ar_object_manager.dart';
+import 'package:flutter/material.dart';
+import 'package:ar_flutter_plugin/ar_flutter_plugin.dart';
+import 'package:ar_flutter_plugin/datatypes/config_planedetection.dart';
+import 'package:ar_flutter_plugin/datatypes/node_types.dart';
+import 'package:ar_flutter_plugin/datatypes/hittest_result_types.dart';
+import 'package:ar_flutter_plugin/models/ar_node.dart';
+import 'package:ar_flutter_plugin/models/ar_hittest_result.dart';
+import 'package:flutter/services.dart';
+import 'package:vector_math/vector_math_64.dart';
+import 'dart:math';
+
+class ObjectsOnPlanesWidget extends StatefulWidget {
+  ObjectsOnPlanesWidget({Key key}) : super(key: key);
+  @override
+  _ObjectsOnPlanesWidgetState createState() => _ObjectsOnPlanesWidgetState();
+}
+
+class _ObjectsOnPlanesWidgetState extends State<ObjectsOnPlanesWidget> {
+  ARSessionManager arSessionManager;
+  ARObjectManager arObjectManager;
+
+  List<ARNode> nodes = [];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: const Text('Local & Web Objects'),
+        ),
+        body: Container(
+            child: Stack(children: [
+          ARView(
+            onARViewCreated: onARViewCreated,
+            planeDetectionConfig: PlaneDetectionConfig.horizontalAndVertical,
+          ),
+          Align(
+            alignment: FractionalOffset.bottomCenter,
+            child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  ElevatedButton(
+                      onPressed: onRemoveEverything,
+                      child: Text("Remove Everything")),
+                ]),
+          )
+        ])));
+  }
+
+  void onARViewCreated(
+      ARSessionManager arSessionManager, ARObjectManager arObjectManager) {
+    this.arSessionManager = arSessionManager;
+    this.arObjectManager = arObjectManager;
+
+    this.arSessionManager.onInitialize(
+          showFeaturePoints: false,
+          showPlanes: true,
+          customPlaneTexturePath: "Images/triangle.png",
+          showWorldOrigin: true,
+        );
+    this.arObjectManager.onInitialize();
+
+    this.arSessionManager.onPlaneOrPointTap = onPlaneOrPointTapped;
+    this.arObjectManager.onNodeTap = onNodeTapped;
+  }
+
+  Future<void> onRemoveEverything() async {
+    nodes.forEach((node) {
+      this.arObjectManager.removeNode(node);
+    });
+  }
+
+  Future<void> onNodeTapped(List<String> nodes) async {
+    var number = nodes.length;
+    this.arSessionManager.onError("Tapped $number node(s)");
+  }
+
+  Future<void> onPlaneOrPointTapped(
+      List<ARHitTestResult> hitTestResults) async {
+    //TODO: This should create anchor and then attach node, not just place a single node!
+    var singleHitTestResult = hitTestResults.firstWhere(
+        (hitTestResult) => hitTestResult.type == ARHitTestResultType.plane);
+    if (singleHitTestResult != null) {
+      var newNode = ARNode(
+          type: NodeType.webGLB,
+          uri:
+              "https://github.com/KhronosGroup/glTF-Sample-Models/raw/master/2.0/Duck/glTF-Binary/Duck.glb",
+          scale: Vector3(0.2, 0.2, 0.2),
+          transformation: singleHitTestResult.worldTransform);
+      bool didAddWebNode = await this.arObjectManager.addNode(newNode);
+      if (didAddWebNode) {
+        this.nodes.add(newNode);
+      }
+    }
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:ar_flutter_plugin_example/examples/objectsonplanesexample.dart';
 import 'package:flutter/material.dart';
 import 'dart:async';
 
@@ -78,11 +79,18 @@ class ExampleList extends StatelessWidget {
               MaterialPageRoute(builder: (context) => DebugOptionsWidget()))),
       Example(
           'Local & Online Objects',
-          'Place and retrieve 3D objects from Flutter Assets and the Web',
+          'Place 3D objects from Flutter assets and the web into the scene',
           () => Navigator.push(
               context,
               MaterialPageRoute(
                   builder: (context) => LocalAndWebObjectsWidget()))),
+      Example(
+          'Objects on Planes',
+          'Place 3D objects on detected planes',
+          () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                  builder: (context) => ObjectsOnPlanesWidget()))),
       Example(
           'Cloud Anchors',
           'Place and retrieve 3D objects using the Google Cloud Anchor API',

--- a/ios/Classes/IosARView.swift
+++ b/ios/Classes/IosARView.swift
@@ -225,6 +225,7 @@ class IosARView: NSObject, FlutterPlatformView, ARSCNViewDelegate, UIGestureReco
         let nodeHitResults: Array<String> = allHitResults.compactMap { $0.node.name }
         if (nodeHitResults.count != 0) {
             self.objectManagerChannel.invokeMethod("onNodeTap", arguments: nodeHitResults)
+            return
         }
             
         let planeTypes: ARHitTestResult.ResultType

--- a/ios/Classes/Serialization/Serializers.swift
+++ b/ios/Classes/Serialization/Serializers.swift
@@ -1,0 +1,27 @@
+import Foundation
+import ARKit
+
+func serializeHitResult(_ result: ARHitTestResult) -> Dictionary<String, Any> {
+    
+    var hitResult = Dictionary<String, Any>(minimumCapacity: 3)
+    if (result.type == .existingPlaneUsingExtent || result.type == .existingPlaneUsingGeometry || result.type == .existingPlane) {
+        hitResult["type"] = 1 // Type plane
+    } else if (result.type == .featurePoint) {
+        hitResult["type"] = 2 // Type point
+    } else {
+        hitResult["type"] = 0 // Type undefined
+    }
+    hitResult["distance"] = result.distance
+    hitResult["worldTransform"] = serializeMatrix(result.worldTransform)
+    return hitResult
+}
+
+// The following code is adapted from Oleksandr Leuschenko' ARKit Flutter Plugin (https://github.com/olexale/arkit_flutter_plugin)
+
+func serializeMatrix(_ matrix: simd_float4x4) -> Array<Float> {
+    return [matrix.columns.0, matrix.columns.1, matrix.columns.2, matrix.columns.3].flatMap { serializeArray($0) }
+}
+
+func serializeArray(_ array: simd_float4) -> Array<Float> {
+    return [array[0], array[1], array[2], array[3]]
+}

--- a/lib/datatypes/hittest_result_types.dart
+++ b/lib/datatypes/hittest_result_types.dart
@@ -1,0 +1,5 @@
+enum ARHitTestResultType {
+  undefined,
+  plane,
+  point,
+}

--- a/lib/managers/ar_object_manager.dart
+++ b/lib/managers/ar_object_manager.dart
@@ -1,6 +1,9 @@
 import 'package:ar_flutter_plugin/models/ar_node.dart';
 import 'package:flutter/services.dart';
 
+// Type definitions to enforce a consistent use of the API
+typedef NodeTapResultHandler = void Function(List<String> nodes);
+
 /// Manages the session configuration, parameters and events of an [ARView]
 class ARObjectManager {
   /// Platform channel used for communication from and to [ARObjectManager]
@@ -8,6 +11,8 @@ class ARObjectManager {
 
   /// Debugging status flag. If true, all platform calls are printed. Defaults to false.
   final bool debug;
+
+  NodeTapResultHandler onNodeTap;
 
   ARObjectManager(int id, {this.debug = false}) {
     _channel = MethodChannel('arobjects_$id');
@@ -25,6 +30,14 @@ class ARObjectManager {
       switch (call.method) {
         case 'onError':
           print(call.arguments);
+          break;
+        case 'onNodeTap':
+          if (onNodeTap != null) {
+            final tappedNodes = call.arguments as List<dynamic>;
+            onNodeTap(tappedNodes
+                .map((tappedNode) => tappedNode.toString())
+                .toList());
+          }
           break;
         default:
           if (debug) {

--- a/lib/models/ar_hittest_result.dart
+++ b/lib/models/ar_hittest_result.dart
@@ -1,0 +1,99 @@
+// The code in this file is adapted from Oleksandr Leuschenko' ARKit Flutter Plugin (https://github.com/olexale/arkit_flutter_plugin)
+
+import 'package:ar_flutter_plugin/datatypes/hittest_result_types.dart';
+import 'package:json_annotation/json_annotation.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+/// A result of an intersection found during a hit-test.
+class ARHitTestResult {
+  ARHitTestResult(
+    this.type,
+    this.distance,
+    this.worldTransform,
+  );
+
+  /// The type of the hit-test result.
+  final ARHitTestResultType type;
+
+  /// The distance from the camera to the intersection in meters.
+  final double distance;
+
+  /// The transformation matrix that defines the intersection’s rotation, translation and scale
+  /// relative to the world.
+  final Matrix4 worldTransform;
+
+  static ARHitTestResult fromJson(Map<String, dynamic> json) =>
+      _$ARHitTestResultFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ARHitTestResultToJson(this);
+}
+
+ARHitTestResult _$ARHitTestResultFromJson(Map<String, dynamic> json) {
+  return ARHitTestResult(
+    const ARHitTestResultTypeConverter().fromJson(json['type'] as int),
+    (json['distance'] as num).toDouble(),
+    const MatrixConverter().fromJson(json['worldTransform'] as List),
+  );
+}
+
+Map<String, dynamic> _$ARHitTestResultToJson(ARHitTestResult instance) {
+  final val = <String, dynamic>{};
+
+  void writeNotNull(String key, dynamic value) {
+    if (value != null) {
+      val[key] = value;
+    }
+  }
+
+  writeNotNull(
+      'type', const ARHitTestResultTypeConverter().toJson(instance.type));
+  val['distance'] = instance.distance;
+  writeNotNull('worldTransform',
+      const MatrixConverter().toJson(instance.worldTransform));
+  return val;
+}
+
+class ARHitTestResultTypeConverter
+    implements JsonConverter<ARHitTestResultType, int> {
+  const ARHitTestResultTypeConverter();
+
+  @override
+  ARHitTestResultType fromJson(int json) {
+    switch (json) {
+      case 1:
+        return ARHitTestResultType.plane;
+      case 2:
+        return ARHitTestResultType.point;
+      default:
+        return ARHitTestResultType.undefined;
+    }
+  }
+
+  @override
+  int toJson(ARHitTestResultType object) {
+    switch (object) {
+      case ARHitTestResultType.plane:
+        return 1;
+      case ARHitTestResultType.point:
+        return 2;
+      default:
+        return 0;
+    }
+  }
+}
+
+class MatrixConverter implements JsonConverter<Matrix4, List<dynamic>> {
+  const MatrixConverter();
+
+  @override
+  Matrix4 fromJson(List<dynamic> json) {
+    return Matrix4.fromList(json.cast<double>());
+  }
+
+  @override
+  List<dynamic> toJson(Matrix4 matrix) {
+    final list = List<double>(16);
+    matrix.copyIntoArray(list);
+    return list;
+  }
+}

--- a/lib/widgets/ar_view.dart
+++ b/lib/widgets/ar_view.dart
@@ -5,7 +5,7 @@ import 'package:ar_flutter_plugin/managers/ar_session_manager.dart';
 import 'package:ar_flutter_plugin/managers/ar_object_manager.dart';
 import 'package:ar_flutter_plugin/datatypes/config_planedetection.dart';
 
-/// Type definitions to enforce a consistent use of the API
+// Type definitions to enforce a consistent use of the API
 typedef ARViewCreatedCallback = void Function(
     ARSessionManager arSessionManager, ARObjectManager arObjectManager);
 


### PR DESCRIPTION
Hi
thank you very much for adding just one plugin to ARcore and Arkit.
I've been working with augmented reality. In IOS only swift there is a Reality composer feature, which allows you to do everything related to AR. Then in the xcode it is only nedded to import the .rcproject file but in the flutter it is not possible to import that file. 

![imagem](https://user-images.githubusercontent.com/75133022/111194509-30d77980-85b3-11eb-9a0f-12bf08dd7893.png)

Do you think you can implement this feature or something like that that has several object anchors for images and that also uses ARKit 4 so that have the latest features
