### PR TITLE
Update ar_session_manager.dart

### DIFF
--- a/lib/managers/ar_session_manager.dart
+++ b/lib/managers/ar_session_manager.dart
@@ -105,9 +105,9 @@ class ARSessionManager {
                 ScaffoldMessenger.of(buildContext).hideCurrentSnackBar)));
   }
 
-  /// Returns a future ImageProvider that contains a screenshot of the current AR Scene
-  Future<ImageProvider> snapshot() async {
+  /// Returns a future Uint8List that contains a screenshot of the current AR Scene
+  Future<Uint8List> snapshot() async {
     final result = await _channel.invokeMethod<Uint8List>('snapshot');
-    return MemoryImage(result!);
+    return result!;
   }
 }


### PR DESCRIPTION
ArSessionManager().snapshot()
ImageProvider to Uint8List return data type was changed for more method functionality. Also with this feature developers can use it for saving to local storage or upload to Internet the picture of ARView :)