### PR TITLE
fix: removed stray ` char from podfile example

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ If you have problems with permissions on iOS (e.g. with the camera view not show
           'PERMISSION_SENSORS=1',
 
           ## dart: PermissionGroup.bluetooth
-          'PERMISSION_BLUETOOTH=1',´
+          'PERMISSION_BLUETOOTH=1',
 
           # add additional permission groups if required
         ]


### PR DESCRIPTION
Found a stray ` character in the example podfile which caused some headache 😅 Thought it was best to fix this to prevent future frustration!