### PR TITLE
fix addNode to return true when node is added to anchor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.7.0
+* Fixing the 'addNode' function to return true when a node is added to an anchor.
+
 ## 0.6.4
 * Flutter 3 compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
-## 0.7.0
-* Fixing the 'addNode' function to return true when a node is added to an anchor.
+## 0.6.5
+* Fixes the 'addNode' function to return true when a node is added to an anchor.
 
 ## 0.6.4
 * Flutter 3 compatibility

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Or manually add this to your `pubspec.yaml` file (and run `flutter pub get`):
 
 ```yaml
 dependencies:
-  ar_flutter_plugin: ^0.7.0
+  ar_flutter_plugin: ^0.6.5
 ```
 
 ### Importing

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Or manually add this to your `pubspec.yaml` file (and run `flutter pub get`):
 
 ```yaml
 dependencies:
-  ar_flutter_plugin: ^0.6.4
+  ar_flutter_plugin: ^0.7.0
 ```
 
 ### Importing

--- a/android/src/main/kotlin/io/carius/lars/ar_flutter_plugin/AndroidARView.kt
+++ b/android/src/main/kotlin/io/carius/lars/ar_flutter_plugin/AndroidARView.kt
@@ -662,6 +662,7 @@ internal class AndroidARView(
                                     val anchorNode = arSceneView.scene.findByName(anchorName) as AnchorNode?
                                     if (anchorNode != null) {
                                         anchorNode.addChild(node)
+                                        completableFutureSuccess.complete(true)
                                     } else {
                                         completableFutureSuccess.complete(false)
                                     }
@@ -689,6 +690,7 @@ internal class AndroidARView(
                                     val anchorNode = arSceneView.scene.findByName(anchorName) as AnchorNode?
                                     if (anchorNode != null) {
                                         anchorNode.addChild(node)
+                                        completableFutureSuccess.complete(true)
                                     } else {
                                         completableFutureSuccess.complete(false)
                                     }
@@ -719,6 +721,7 @@ internal class AndroidARView(
                                     val anchorNode = arSceneView.scene.findByName(anchorName) as AnchorNode?
                                     if (anchorNode != null) {
                                         anchorNode.addChild(node)
+                                        completableFutureSuccess.complete(true)
                                     } else {
                                         completableFutureSuccess.complete(false)
                                     }
@@ -751,6 +754,7 @@ internal class AndroidARView(
                                     val anchorNode = arSceneView.scene.findByName(anchorName) as AnchorNode?
                                     if (anchorNode != null) {
                                         anchorNode.addChild(node)
+                                        completableFutureSuccess.complete(true)
                                     } else {
                                         completableFutureSuccess.complete(false)
                                     }

--- a/ios/Classes/IosARView.swift
+++ b/ios/Classes/IosARView.swift
@@ -371,6 +371,7 @@ class IosARView: NSObject, FlutterPlatformView, ARSCNViewDelegate, UIGestureReco
                                     if let anchor = self.anchorCollection[anchorName]{
                                         // Attach node to the top-level node of the specified anchor
                                         self.sceneView.node(for: anchor)?.addChildNode(node)
+                                        promise(.success(true))
                                     } else {
                                         promise(.success(false))
                                     }
@@ -402,6 +403,7 @@ class IosARView: NSObject, FlutterPlatformView, ARSCNViewDelegate, UIGestureReco
                                         if let anchor = self.anchorCollection[anchorName]{
                                             // Attach node to the top-level node of the specified anchor
                                             self.sceneView.node(for: anchor)?.addChildNode(node)
+                                            promise(.success(true))
                                         } else {
                                             promise(.success(false))
                                         }
@@ -435,6 +437,7 @@ class IosARView: NSObject, FlutterPlatformView, ARSCNViewDelegate, UIGestureReco
                                     if let anchor = self.anchorCollection[anchorName]{
                                         // Attach node to the top-level node of the specified anchor
                                         self.sceneView.node(for: anchor)?.addChildNode(node)
+                                        promise(.success(true))
                                     } else {
                                         promise(.success(false))
                                     }
@@ -467,6 +470,7 @@ class IosARView: NSObject, FlutterPlatformView, ARSCNViewDelegate, UIGestureReco
                                     if let anchor = self.anchorCollection[anchorName]{
                                         // Attach node to the top-level node of the specified anchor
                                         self.sceneView.node(for: anchor)?.addChildNode(node)
+                                        promise(.success(true))
                                     } else {
                                         promise(.success(false))
                                     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ar_flutter_plugin
 description: Flutter Plugin for creating (collaborative) Augmented Reality experiences - Supports ARKit for iOS and ARCore for Android devices.
-version: 0.7.0
+version: 0.6.5
 homepage: https://lars.carius.io
 repository: https://github.com/CariusLars/ar_flutter_plugin
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ar_flutter_plugin
 description: Flutter Plugin for creating (collaborative) Augmented Reality experiences - Supports ARKit for iOS and ARCore for Android devices.
-version: 0.6.4
+version: 0.7.0
 homepage: https://lars.carius.io
 repository: https://github.com/CariusLars/ar_flutter_plugin
 


### PR DESCRIPTION
Hey,
as mentioned in #113 the addNode function returns false every time when the node is added to an anchor.
In the changes from v0.6.3 true is only returned if the node is added to the scene and not if the node is added to an anchor.

I added the return for each Node-Type in Andorid and iOS.
I have checked it for Andoroid but can't do it for iOS.