### PR TITLE
null safety errors removed from debugOptionsExample

### DIFF
--- a/example/lib/examples/cloudanchorexample.dart
+++ b/example/lib/examples/cloudanchorexample.dart
@@ -239,8 +239,8 @@ class _CloudAnchorWidgetState extends State<CloudAnchorWidget> {
     if (singleHitTestResult != null) {
       var newAnchor = ARPlaneAnchor(
           transformation: singleHitTestResult.worldTransform, ttl: 2);
-      bool didAddAnchor = await this.arAnchorManager.addAnchor(newAnchor);
-      if (didAddAnchor) {
+      bool? didAddAnchor = await this.arAnchorManager.addAnchor(newAnchor);
+      if (didAddAnchor ?? false) {
         this.anchors.add(newAnchor);
         // Add note to anchor
         var newNode = ARNode(
@@ -251,9 +251,9 @@ class _CloudAnchorWidgetState extends State<CloudAnchorWidget> {
             position: Vector3(0.0, 0.0, 0.0),
             rotation: Vector4(1.0, 0.0, 0.0, 0.0),
             data: {"onTapText": "Ouch, that hurt!"});
-        bool didAddNodeToAnchor =
+        bool? didAddNodeToAnchor =
             await this.arObjectManager.addNode(newNode, planeAnchor: newAnchor);
-        if (didAddNodeToAnchor) {
+        if (didAddNodeToAnchor ?? false) {
           this.nodes.add(newNode);
           setState(() {
             readyToUpload = true;

--- a/example/lib/examples/debugoptionsexample.dart
+++ b/example/lib/examples/debugoptionsexample.dart
@@ -7,14 +7,14 @@ import 'package:ar_flutter_plugin/ar_flutter_plugin.dart';
 import 'package:ar_flutter_plugin/datatypes/config_planedetection.dart';
 
 class DebugOptionsWidget extends StatefulWidget {
-  DebugOptionsWidget({Key key}) : super(key: key);
+  DebugOptionsWidget({Key? key}) : super(key: key);
   @override
   _DebugOptionsWidgetState createState() => _DebugOptionsWidgetState();
 }
 
 class _DebugOptionsWidgetState extends State<DebugOptionsWidget> {
-  ARSessionManager arSessionManager;
-  ARObjectManager arObjectManager;
+  late ARSessionManager arSessionManager;
+  late ARObjectManager arObjectManager;
   bool _showFeaturePoints = false;
   bool _showPlanes = false;
   bool _showWorldOrigin = false;


### PR DESCRIPTION
There were these null-safety errors, in the file DebugOptionsExample that have been removed.