### PR TITLE
Bump up ARCore version to 1.33 to support Apple Silicon

### DIFF
--- a/ios/ar_flutter_plugin.podspec
+++ b/ios/ar_flutter_plugin.podspec
@@ -20,7 +20,7 @@ A Flutter plugin for shared AR experiences supporting Android and iOS.
   s.static_framework = true
   #s.dependency 'ARCore/CloudAnchors', '~> 1.12.0'
   #s.dependency 'ARCore', '~> 1.2.0'
-  s.dependency 'ARCore/CloudAnchors', '~> 1.32.0'
+  s.dependency 'ARCore/CloudAnchors', '~> 1.33.0' # Updated from 1.32 to 1.33 to support Apple Silicon, info here: https://github.com/google-ar/arcore-ios-sdk/issues/59#issuecomment-1219756010
   s.platform = :ios, '13.0'
 
 


### PR DESCRIPTION
Context here: https://github.com/google-ar/arcore-ios-sdk/issues/59#issuecomment-1219756010

The current linked version of ARCore, 1.32, does not support Apple Silicon. This means you can't use the iOS simulator at all on Apple Silicon devices if this library is in the project.

I just bumped the minimum version up to 1.33 and all seems to be well.