### PR TITLE
Replace-print-statements-with-developer.log

### DIFF
--- a/lib/managers/ar_anchor_manager.dart
+++ b/lib/managers/ar_anchor_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:ar_flutter_plugin/models/ar_anchor.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/material.dart';
@@ -27,9 +29,8 @@ class ARAnchorManager {
   ARAnchorManager(int id, {this.debug = false}) {
     _channel = MethodChannel('aranchors_$id');
     _channel.setMethodCallHandler(_platformCallHandler);
-    if (debug) {
-      print("ARAnchorManager initialized");
-    }
+
+    developer.log("$runtimeType initialized");
   }
 
   /// Activates collaborative AR mode (using Google Cloud Anchors)
@@ -38,19 +39,21 @@ class ARAnchorManager {
   }
 
   Future<dynamic> _platformCallHandler(MethodCall call) async {
-    if (debug) {
-      print('_platformCallHandler call ${call.method} ${call.arguments}');
-    }
+    developer.log('_platformCallHandler call ${call.method} ${call.arguments}');
+
     try {
       switch (call.method) {
         case 'onError':
-          print(call.arguments);
+          developer.log(call.arguments);
           break;
         case 'onCloudAnchorUploaded':
           final name = call.arguments["name"];
           final cloudanchorid = call.arguments["cloudanchorid"];
-          print(
-              "UPLOADED ANCHOR WITH ID: " + cloudanchorid + ", NAME: " + name);
+
+          developer.log(
+            "UPLOADED ANCHOR WITH ID: " + cloudanchorid + ", NAME: " + name,
+          );
+
           final currentAnchor =
               pendingAnchors.where((element) => element.name == name).first;
           // Update anchor with cloud anchor ID
@@ -72,13 +75,15 @@ class ARAnchorManager {
             return serializedAnchor["name"];
           }
         default:
-          if (debug) {
-            print('Unimplemented method ${call.method} ');
-          }
+          developer.log('Unknown method ${call.method}');
       }
     } catch (e) {
-      print('Error caught: ' + e.toString());
+      developer.log(
+        'Exception in platform call handler: $e',
+        name: 'ar_anchor_manager',
+      );
     }
+
     return Future.value();
   }
 
@@ -110,7 +115,8 @@ class ARAnchorManager {
 
   /// Try to download anchor with the given ID from the Google Cloud Anchor API and add it to the scene
   Future<bool?> downloadAnchor(String cloudanchorid) async {
-    print("TRYING TO DOWNLOAD ANCHOR WITH ID " + cloudanchorid);
+    developer.log("TRYING TO DOWNLOAD ANCHOR WITH ID " + cloudanchorid);
+
     _channel
         .invokeMethod<bool>('downloadAnchor', {"cloudanchorid": cloudanchorid});
   }

--- a/lib/managers/ar_location_manager.dart
+++ b/lib/managers/ar_location_manager.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:developer' as developer;
+
 import 'package:geolocator/geolocator.dart';
 
 /// Can be used to get the current location of the device, update it and handle location permissions
@@ -80,7 +82,10 @@ class ARLocationManager {
     locationStream =
         Geolocator.getPositionStream(desiredAccuracy: LocationAccuracy.high)
             .listen((Position position) {
-      //print(position.latitude.toString() + ', ' + position.longitude.toString());
+      developer.log(
+        '$runtimeType::getPositionStream: ${position.latitude}, ${position.longitude}',
+      );
+
       currentLocation = position;
     });
 

--- a/lib/managers/ar_object_manager.dart
+++ b/lib/managers/ar_object_manager.dart
@@ -1,3 +1,4 @@
+import 'dart:developer' as developer;
 import 'dart:typed_data';
 
 import 'package:ar_flutter_plugin/models/ar_anchor.dart';
@@ -35,19 +36,17 @@ class ARObjectManager {
   ARObjectManager(int id, {this.debug = false}) {
     _channel = MethodChannel('arobjects_$id');
     _channel.setMethodCallHandler(_platformCallHandler);
-    if (debug) {
-      print("ARObjectManager initialized");
-    }
+
+    developer.log("$runtimeType initialized");
   }
 
   Future<void> _platformCallHandler(MethodCall call) {
-    if (debug) {
-      print('_platformCallHandler call ${call.method} ${call.arguments}');
-    }
+    developer.log('_platformCallHandler call ${call.method} ${call.arguments}');
+
     try {
       switch (call.method) {
         case 'onError':
-          print(call.arguments);
+          developer.log(call.arguments);
           break;
         case 'onNodeTap':
           if (onNodeTap != null) {
@@ -104,12 +103,10 @@ class ARObjectManager {
           }
           break;
         default:
-          if (debug) {
-            print('Unimplemented method ${call.method} ');
-          }
+          developer.log('Unimplemented method ${call.method}');
       }
     } catch (e) {
-      print('Error caught: ' + e.toString());
+      developer.log('Error in $runtimeType: $e');
     }
     return Future.value();
   }

--- a/lib/managers/ar_session_manager.dart
+++ b/lib/managers/ar_session_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'dart:typed_data';
 import 'package:ar_flutter_plugin/models/ar_hittest_result.dart';
 import 'package:flutter/material.dart';
@@ -28,21 +30,19 @@ class ARSessionManager {
       {this.debug = false}) {
     _channel = MethodChannel('arsession_$id');
     _channel.setMethodCallHandler(_platformCallHandler);
-    if (debug) {
-      print("ARSessionManager initialized");
-    }
+
+    developer.log("ARSessionManager initialized");
   }
 
   Future<void> _platformCallHandler(MethodCall call) {
-    if (debug) {
-      print('_platformCallHandler call ${call.method} ${call.arguments}');
-    }
+    developer.log('_platformCallHandler call ${call.method} ${call.arguments}');
+
     try {
       switch (call.method) {
         case 'onError':
           if (onError != null) {
             onError(call.arguments[0]);
-            print(call.arguments);
+            developer.log(call.arguments);
           }
           break;
         case 'onPlaneOrPointTap':
@@ -62,13 +62,12 @@ class ARSessionManager {
           _channel.invokeMethod<void>("dispose");
           break;
         default:
-          if (debug) {
-            print('Unimplemented method ${call.method} ');
-          }
+          developer.log('Unimplemented method ${call.method} ');
       }
     } catch (e) {
-      print('Error caught: ' + e.toString());
+      developer.log('Error in ARSessionManager._platformCallHandler: $e');
     }
+
     return Future.value();
   }
 
@@ -114,7 +113,7 @@ class ARSessionManager {
     try {
       await _channel.invokeMethod<void>("dispose");
     } catch (e) {
-      print(e);
+      developer.log("Error disposing ARSessionManager: $e");
     }
   }
 

--- a/lib/widgets/ar_view.dart
+++ b/lib/widgets/ar_view.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:ar_flutter_plugin/managers/ar_anchor_manager.dart';
 import 'package:ar_flutter_plugin/managers/ar_location_manager.dart';
 import 'package:flutter/material.dart';
@@ -60,7 +62,8 @@ class AndroidARView implements PlatformARView {
 
   @override
   void onPlatformViewCreated(int id) {
-    print("Android platform view created!");
+    developer.log("Android platform view created!");
+
     createManagers(id, _context, _arViewCreatedCallback, _planeDetectionConfig);
   }
 
@@ -95,7 +98,8 @@ class IosARView implements PlatformARView {
 
   @override
   void onPlatformViewCreated(int id) {
-    print("iOS platform view created!");
+    developer.log("iOS platform view created!");
+
     createManagers(id, _context, _arViewCreatedCallback, _planeDetectionConfig);
   }
 


### PR DESCRIPTION
Reason behind this PR:
- Logging in release builds: Unlike print statements, developer.log can be configured to log selectively in release builds as well. This can be useful for capturing critical information or errors in production environments without exposing sensitive data or cluttering the console with excessive log output.
- Performance optimizations: Techniques like asynchronous logging or buffered I/O, minimizing the impact on app performance and responsiveness.